### PR TITLE
Use enriched constant in SpanEventViewGenerator

### DIFF
--- a/hypertrace-core-view-generator/build.gradle.kts
+++ b/hypertrace-core-view-generator/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
   implementation(project(":hypertrace-core-view-generator-api"))
   implementation("org.hypertrace.core.viewgenerator:view-generator-framework:0.1.16")
   implementation("org.hypertrace.core.datamodel:data-model:0.1.9")
-  implementation("org.hypertrace.core.spannormalizer:raw-span-constants:0.1.22")
+  implementation("org.hypertrace.traceenricher:enriched-span-constants:0.3.4")
 
   implementation("com.google.code.findbugs:jsr305:3.0.2")
   implementation("org.apache.avro:avro:1.9.2")

--- a/hypertrace-core-view-generator/src/main/java/org/hypertrace/core/viewgenerator/generators/SpanEventViewGenerator.java
+++ b/hypertrace-core-view-generator/src/main/java/org/hypertrace/core/viewgenerator/generators/SpanEventViewGenerator.java
@@ -51,7 +51,7 @@ public class SpanEventViewGenerator extends BaseViewGenerator<SpanEventView> {
     builder.setTenantId(event.getCustomerId());
     builder.setSpanId(event.getEventId());
     builder.setEventName(event.getEventName());
-    builder.setSpanKind(getSpanKindFromRawSpan(event));
+    builder.setSpanKind(getSpanKindFromEnrichedSpan(event));
 
     // parent_span_id
     ByteBuffer parentEventId = childToParentEventIds.get(event.getEventId());
@@ -76,17 +76,17 @@ public class SpanEventViewGenerator extends BaseViewGenerator<SpanEventView> {
     builder.setDisplaySpanName(event.getEventName());
 
     // status_code
-    builder.setStatusCode(getStatusCodeFromRawSpan(event));
+    builder.setStatusCode(getStatusCodeFromEnrichedSpan(event));
 
     return builder;
   }
 
-  static String getStatusCodeFromRawSpan(Event e) {
+  static String getStatusCodeFromEnrichedSpan(Event e) {
     return SpanAttributeUtils.getStringAttribute(
         e, EnrichedSpanConstants.getValue(Api.API_STATUS_CODE));
   }
 
-  static String getSpanKindFromRawSpan(Event e) {
+  static String getSpanKindFromEnrichedSpan(Event e) {
     return SpanAttributeUtils.getStringAttributeWithDefault(
         e, EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_SPAN_TYPE),
         EnrichedSpanConstants.getValue(BoundaryTypeValue.BOUNDARY_TYPE_VALUE_UNSPECIFIED));

--- a/hypertrace-core-view-generator/src/test/java/org/hypertrace/core/viewgenerator/generators/MockUtils.java
+++ b/hypertrace-core-view-generator/src/test/java/org/hypertrace/core/viewgenerator/generators/MockUtils.java
@@ -14,6 +14,7 @@ public class MockUtils {
     Event e = mock(Event.class);
 
     Map<String, AttributeValue> attributes = new HashMap<>();
+    when(e.getEnrichedAttributes()).thenReturn(Attributes.newBuilder().setAttributeMap(attributes).build());
     when(e.getAttributes()).thenReturn(Attributes.newBuilder().setAttributeMap(attributes).build());
     when(e.getServiceName()).thenReturn("service1");
 

--- a/hypertrace-core-view-generator/src/test/java/org/hypertrace/core/viewgenerator/generators/SpanEventViewGeneratorTest.java
+++ b/hypertrace-core-view-generator/src/test/java/org/hypertrace/core/viewgenerator/generators/SpanEventViewGeneratorTest.java
@@ -4,30 +4,44 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.hypertrace.core.datamodel.AttributeValue;
 import org.hypertrace.core.datamodel.Event;
+import org.hypertrace.traceenricher.enrichedspan.constants.EnrichedSpanConstants;
+import org.hypertrace.traceenricher.enrichedspan.constants.v1.Api;
+import org.hypertrace.traceenricher.enrichedspan.constants.v1.BoundaryTypeValue;
+import org.hypertrace.traceenricher.enrichedspan.constants.v1.CommonAttribute;
 import org.junit.jupiter.api.Test;
 
 public class SpanEventViewGeneratorTest {
+
   @Test
   public void spanKind() {
     Event mockEvent = MockUtils.createEvent();
     assertEquals("UNKNOWN", SpanEventViewGenerator.getSpanKindFromRawSpan(mockEvent));
 
     mockEvent
-        .getAttributes()
+        .getEnrichedAttributes()
         .getAttributeMap()
-        .put("span.kind", AttributeValue.newBuilder().setValue("server").build());
+        .put(EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_SPAN_TYPE),
+            buildAttributeValue(EnrichedSpanConstants.getValue(BoundaryTypeValue.BOUNDARY_TYPE_VALUE_ENTRY)));
     assertEquals("ENTRY", SpanEventViewGenerator.getSpanKindFromRawSpan(mockEvent));
 
     mockEvent
-        .getAttributes()
+        .getEnrichedAttributes()
         .getAttributeMap()
-        .put("span.kind", AttributeValue.newBuilder().setValue("client").build());
+        .put(EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_SPAN_TYPE),
+            buildAttributeValue(EnrichedSpanConstants.getValue(BoundaryTypeValue.BOUNDARY_TYPE_VALUE_EXIT)));
     assertEquals("EXIT", SpanEventViewGenerator.getSpanKindFromRawSpan(mockEvent));
+
+    mockEvent
+        .getEnrichedAttributes()
+        .getAttributeMap()
+        .put(EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_SPAN_TYPE),
+            buildAttributeValue(EnrichedSpanConstants.getValue(BoundaryTypeValue.BOUNDARY_TYPE_VALUE_UNSPECIFIED)));
+    assertEquals("UNKNOWN", SpanEventViewGenerator.getSpanKindFromRawSpan(mockEvent));
 
     mockEvent
         .getAttributes()
         .getAttributeMap()
-        .put("span.kind", AttributeValue.newBuilder().setValue("consumer").build());
+        .put("span.kind", buildAttributeValue("consumer"));
     assertEquals("UNKNOWN", SpanEventViewGenerator.getSpanKindFromRawSpan(mockEvent));
   }
 
@@ -37,15 +51,15 @@ public class SpanEventViewGeneratorTest {
     assertEquals(null, SpanEventViewGenerator.getStatusCodeFromRawSpan(mockEvent));
 
     mockEvent
-        .getAttributes()
+        .getEnrichedAttributes()
         .getAttributeMap()
-        .put("http.status_code", AttributeValue.newBuilder().setValue("200").build());
+        .put(EnrichedSpanConstants.getValue(Api.API_STATUS_CODE),
+            buildAttributeValue("200"));
     assertEquals("200", SpanEventViewGenerator.getStatusCodeFromRawSpan(mockEvent));
 
-    mockEvent
-        .getAttributes()
-        .getAttributeMap()
-        .put("status.code", AttributeValue.newBuilder().setValue("ok").build());
-    assertEquals("ok", SpanEventViewGenerator.getStatusCodeFromRawSpan(mockEvent));
+  }
+
+  static AttributeValue buildAttributeValue(String value) {
+    return AttributeValue.newBuilder().setValue(value).build();
   }
 }

--- a/hypertrace-core-view-generator/src/test/java/org/hypertrace/core/viewgenerator/generators/SpanEventViewGeneratorTest.java
+++ b/hypertrace-core-view-generator/src/test/java/org/hypertrace/core/viewgenerator/generators/SpanEventViewGeneratorTest.java
@@ -15,47 +15,47 @@ public class SpanEventViewGeneratorTest {
   @Test
   public void spanKind() {
     Event mockEvent = MockUtils.createEvent();
-    assertEquals("UNKNOWN", SpanEventViewGenerator.getSpanKindFromRawSpan(mockEvent));
+    assertEquals("UNKNOWN", SpanEventViewGenerator.getSpanKindFromEnrichedSpan(mockEvent));
 
     mockEvent
         .getEnrichedAttributes()
         .getAttributeMap()
         .put(EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_SPAN_TYPE),
             buildAttributeValue(EnrichedSpanConstants.getValue(BoundaryTypeValue.BOUNDARY_TYPE_VALUE_ENTRY)));
-    assertEquals("ENTRY", SpanEventViewGenerator.getSpanKindFromRawSpan(mockEvent));
+    assertEquals("ENTRY", SpanEventViewGenerator.getSpanKindFromEnrichedSpan(mockEvent));
 
     mockEvent
         .getEnrichedAttributes()
         .getAttributeMap()
         .put(EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_SPAN_TYPE),
             buildAttributeValue(EnrichedSpanConstants.getValue(BoundaryTypeValue.BOUNDARY_TYPE_VALUE_EXIT)));
-    assertEquals("EXIT", SpanEventViewGenerator.getSpanKindFromRawSpan(mockEvent));
+    assertEquals("EXIT", SpanEventViewGenerator.getSpanKindFromEnrichedSpan(mockEvent));
 
     mockEvent
         .getEnrichedAttributes()
         .getAttributeMap()
         .put(EnrichedSpanConstants.getValue(CommonAttribute.COMMON_ATTRIBUTE_SPAN_TYPE),
             buildAttributeValue(EnrichedSpanConstants.getValue(BoundaryTypeValue.BOUNDARY_TYPE_VALUE_UNSPECIFIED)));
-    assertEquals("UNKNOWN", SpanEventViewGenerator.getSpanKindFromRawSpan(mockEvent));
+    assertEquals("UNKNOWN", SpanEventViewGenerator.getSpanKindFromEnrichedSpan(mockEvent));
 
     mockEvent
         .getAttributes()
         .getAttributeMap()
         .put("span.kind", buildAttributeValue("consumer"));
-    assertEquals("UNKNOWN", SpanEventViewGenerator.getSpanKindFromRawSpan(mockEvent));
+    assertEquals("UNKNOWN", SpanEventViewGenerator.getSpanKindFromEnrichedSpan(mockEvent));
   }
 
   @Test
   public void statusCode() {
     Event mockEvent = MockUtils.createEvent();
-    assertEquals(null, SpanEventViewGenerator.getStatusCodeFromRawSpan(mockEvent));
+    assertEquals(null, SpanEventViewGenerator.getStatusCodeFromEnrichedSpan(mockEvent));
 
     mockEvent
         .getEnrichedAttributes()
         .getAttributeMap()
         .put(EnrichedSpanConstants.getValue(Api.API_STATUS_CODE),
             buildAttributeValue("200"));
-    assertEquals("200", SpanEventViewGenerator.getStatusCodeFromRawSpan(mockEvent));
+    assertEquals("200", SpanEventViewGenerator.getStatusCodeFromEnrichedSpan(mockEvent));
 
   }
 


### PR DESCRIPTION
Spankind & Status code needs to bet set for the SpanEventView object
Currently we are deriving the value for these attributes from raw-constants 

The change is to instead use enriched constants, which are being populated in trace-enricher
For span kind use: `org.hypertrace.traceenricher.enrichedspan.constants.v1.COMMON_ATTRIBUTE_SPAN_TYPE`
For status code use: `org.hypertrace.traceenricher.enrichedspan.constants.v1.Api.API_STATUS_CODE`